### PR TITLE
Add --extension option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .pub/
 build/
 packages
+.packages
 pubspec.lock

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Uninstall
 
 ```shell
 Usage: stagedive -n <new project folder> -p <template project> -t <template name>
+    -e, --extension          Template extension, stripped during copy
     -s, --settings           Prints settings
     -h, --help               Shows this message
     -l, --list               List available templates
@@ -56,6 +57,12 @@ There is one extra variable: `basename`
  
 File-Content-Format: `<%= varname %>`  
 File-Name-Format: `{varname}`
+
+The `-e` option allows you to specify a template extension that will
+be stripped when copying files from the template to their new
+locations. This lets you distinguish between Dart files and Dart file
+templates, for example, in situations where you have tools that
+blindly operate on all `.dart` files in your project.
 
 ### Sample manifest.yaml
 

--- a/lib/cmdline/Application.dart
+++ b/lib/cmdline/Application.dart
@@ -188,7 +188,7 @@ class Application {
                     }
                     else {
                         final File src = new File(entity.path);
-                        final String targetFilename = _setVarInTargetFilename(settings,"${dirTargetBase.path}${path.separator}${entityPath}");
+                        final String targetFilename = _setVarInTargetFilename(config, settings,"${dirTargetBase.path}${path.separator}${entityPath}");
                         final File target = new File(targetFilename);
 
                         _logger.fine("Copy: ${src.path} -> ${target.path}");
@@ -236,7 +236,11 @@ class Application {
         Logger.root.onRecord.listen(new LogPrintHandler(messageFormat: "%m"));
     }
 
-    String _setVarInTargetFilename(final List<Setting> settings, String filename) {
+    String _setVarInTargetFilename(Config config, final List<Setting> settings, String filename) {
+        if (filename.endsWith(config.extension)) {
+            var index = filename.lastIndexOf(config.extension);
+            filename = filename.substring(0, index);
+        }
         settings.forEach((final Setting setting) {
             if(filename.indexOf("{${setting.key}") != -1) {
                 filename = filename.replaceAll("{${setting.key}}",setting.value);

--- a/lib/cmdline/Config.dart
+++ b/lib/cmdline/Config.dart
@@ -20,6 +20,7 @@ class Config {
         _settings[Options._ARG_NEW_PROJECT_DIR]     = '';
         _settings[Options._ARG_TEMPLATE_PROJECT]    = '';
         _settings[Options._ARG_TEMPLATE]            = '';
+        _settings[Options._ARG_EXTENSION]           = '';
 
         _settings[Config._MANIFEST]                 = 'manifest.yaml';
 
@@ -36,6 +37,7 @@ class Config {
     String get newprojectdir => _settings[Options._ARG_NEW_PROJECT_DIR];
     String get templateproject => _settings[Options._ARG_TEMPLATE_PROJECT];
     String get template => _settings[Options._ARG_TEMPLATE];
+    String get extension => _settings[Options._ARG_EXTENSION];
 
     String get manifestfile => _settings[Config._MANIFEST];
 
@@ -102,6 +104,10 @@ class Config {
 
         if(_argResults.wasParsed(Options._ARG_TEMPLATE)) {
             _settings[Options._ARG_TEMPLATE] = _argResults[Options._ARG_TEMPLATE];
+        }
+
+        if (_argResults.wasParsed(Options._ARG_EXTENSION)) {
+            _settings[Options._ARG_EXTENSION] = _argResults[Options._ARG_EXTENSION];
         }
     }
 

--- a/lib/cmdline/Options.dart
+++ b/lib/cmdline/Options.dart
@@ -4,6 +4,7 @@ part of stagedive;
 class Options {
     static const APPNAME                      = 'stagedive';
 
+    static const _ARG_EXTENSION               = 'extension';
     static const _ARG_HELP                    = 'help';
     static const _ARG_LOGLEVEL                = 'loglevel';
     static const _ARG_SETTINGS                = 'settings';
@@ -56,6 +57,8 @@ class Options {
             ..addOption(_ARG_TEMPLATE,           abbr: 't', help: "Template name (e.g. console)")
 
             ..addOption(_ARG_LOGLEVEL,           abbr: 'v', help: "Sets the appropriate loglevel", allowed: ['info', 'debug', 'warning'])
+
+            ..addOption(_ARG_EXTENSION,          abbr: 'e', help: "Template extension, stripped during copy", defaultsTo: '')
 
         ;
 


### PR DESCRIPTION
We want to include a Stagedive template in one of our libraries, but we ran into a problem. Dartdoc attempts to run against (and thus parse) all `.dart` files in `lib/` and there is apparently no way to tell it to skip certain files. We thought this would be a reasonably nice solution. I've added an option to Stagedive so that it can allow a file extension for templates that will be stripped when the files are copied.

For example, one might use `.tmpl`, so a Dart file might be `cli.dart.tmpl`. When the template is used, assuming the `-e .tmpl` option is set, the `.tmpl` will be stripped and the file that will end up in the new project will be called `cli.dart`.
